### PR TITLE
Use next_reviews_at and available_at Summary data to drive push notifications

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.leapsoftware.leapforwanikani"
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 100
-        versionName "1.0.0"
+        versionCode 101
+        versionName "1.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/leapsoftware/leapforwanikani/MainActivity.kt
+++ b/app/src/main/java/com/leapsoftware/leapforwanikani/MainActivity.kt
@@ -29,6 +29,7 @@ import com.leapsoftware.leapforwanikani.data.source.remote.api.WKReport
 import com.leapsoftware.leapforwanikani.utils.LeapNotificationManager
 import com.leapsoftware.leapforwanikani.utils.PreferencesManager
 import kotlinx.android.synthetic.main.activity_main.*
+import java.util.*
 
 
 class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener {
@@ -37,25 +38,6 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
     private lateinit var mainViewModel: MainViewModel
     private lateinit var mainNavDrawerAdapter: MainNavDrawerAdapter
-
-    companion object {
-        const val EXTRAS_REQUEST_CODE = "leap_notification_action_request_code"
-        const val REQUEST_CODE_LESSONS = 1
-        const val REQUEST_CODE_REVIEWS = 2
-        const val REQUEST_CODE_LESSONS_AND_REVIEWS = 3
-
-        fun getActivityRequestCode(summaryData: WKData.SummaryData): Int {
-            return if (summaryData.lessons.isNotEmpty() && summaryData.reviews.isNotEmpty()) {
-                REQUEST_CODE_LESSONS_AND_REVIEWS
-            } else if (summaryData.lessons.isNotEmpty()) {
-                REQUEST_CODE_LESSONS
-            } else if (summaryData.reviews.isNotEmpty()) {
-                REQUEST_CODE_REVIEWS
-            } else {
-                -1
-            }
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -74,10 +56,10 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         mainNavDrawerAdapter.setOnItemSelectedListener(this)
 
         // Respond to notification open actions
-        val requestCode: Int = intent.getIntExtra(EXTRAS_REQUEST_CODE, -1)
+        val requestCode: Int = intent.getIntExtra(LeapNotificationManager.EXTRAS_REQUEST_CODE, -1)
         when (requestCode) {
-            REQUEST_CODE_LESSONS -> WebDelegate.openLessons(this)
-            REQUEST_CODE_REVIEWS -> WebDelegate.openReviews(this)
+            LeapNotificationManager.REQUEST_CODE_LESSONS -> WebDelegate.openLessons(this)
+            LeapNotificationManager.REQUEST_CODE_REVIEWS -> WebDelegate.openReviews(this)
         }
 
         val offlineSnackbar = Snackbar.make(

--- a/app/src/main/java/com/leapsoftware/leapforwanikani/utils/LeapExtensions.kt
+++ b/app/src/main/java/com/leapsoftware/leapforwanikani/utils/LeapExtensions.kt
@@ -1,0 +1,23 @@
+package com.leapsoftware.leapforwanikani.utils
+
+import com.leapsoftware.leapforwanikani.data.Lesson
+import com.leapsoftware.leapforwanikani.data.source.remote.api.WKData
+import java.util.*
+
+fun WKData.SummaryData.hasAvailableReviews(): Boolean {
+    return when (next_reviews_at?.before(Date())) {
+        null -> { // next_views_at is null
+            false // so return false
+        }
+        false -> { // next reviews available after now
+            false
+        }
+        true -> { // next reviews available before now
+            true
+        }
+    }
+}
+
+fun Lesson.hasAvailableLessons(): Boolean {
+    return available_at.before(Date())
+}

--- a/app/src/main/java/com/leapsoftware/leapforwanikani/utils/LeapNotificationManager.kt
+++ b/app/src/main/java/com/leapsoftware/leapforwanikani/utils/LeapNotificationManager.kt
@@ -11,12 +11,19 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.leapsoftware.leapforwanikani.MainActivity
 import com.leapsoftware.leapforwanikani.R
+import com.leapsoftware.leapforwanikani.data.source.remote.api.WKData
+import java.util.*
 
 class LeapNotificationManager(val context: Context) {
 
     private val TAG by lazy { LeapNotificationManager::class.java.simpleName }
 
     companion object {
+        const val EXTRAS_REQUEST_CODE = "leap_notification_action_request_code"
+        const val REQUEST_CODE_LESSONS = 1
+        const val REQUEST_CODE_REVIEWS = 2
+        const val REQUEST_CODE_LESSONS_AND_REVIEWS = 3
+
         private const val NOTIFICATION_CHANNEL_LESSONS_ID = "channel_id_lessons"
         private const val NOTIFICATION_CHANNEL_REVIEWS_ID = "channel_id_reviews"
         private const val NOTIFICATION_CHANNEL_LESSONS_AND_REVIEWS_ID = "channel_id_lessons_reviews"
@@ -29,9 +36,26 @@ class LeapNotificationManager(val context: Context) {
         private const val PENDING_INTENT_REVIEWS = 101
         private const val PENDING_INTENT_LESSONS_AND_REVIEWS = 102
 
+        fun getRequestCode(summaryData: WKData.SummaryData): Int {
+            return if (summaryData.lessons.isNotEmpty()
+                && summaryData.lessons[0].hasAvailableLessons()
+                && summaryData.hasAvailableReviews()
+            ) {
+                REQUEST_CODE_LESSONS_AND_REVIEWS
+            } else if (summaryData.lessons.isNotEmpty()
+                && summaryData.lessons[0].hasAvailableLessons()
+            ) {
+                REQUEST_CODE_LESSONS
+            } else if (summaryData.hasAvailableReviews()) {
+                REQUEST_CODE_REVIEWS
+            } else {
+                -1
+            }
+        }
+
         fun sendNotification(context: Context, requestCode: Int) {
             val intent = Intent(context, MainActivity::class.java)
-                .putExtra(MainActivity.EXTRAS_REQUEST_CODE, requestCode)
+                .putExtra(EXTRAS_REQUEST_CODE, requestCode)
 
             var channelId = ""
             var notificationId = -1
@@ -40,21 +64,21 @@ class LeapNotificationManager(val context: Context) {
             var text = ""
 
             when (requestCode) {
-                MainActivity.REQUEST_CODE_LESSONS -> {
+                REQUEST_CODE_LESSONS -> {
                     channelId = NOTIFICATION_CHANNEL_LESSONS_ID
                     notificationId = NOTIFICATION_ID_LESSONS
                     pendingIntentCode = PENDING_INTENT_LESSONS
                     title = context.getString(R.string.notification_title_lessons)
                     text = context.getString(R.string.notification_text_lessons)
                 }
-                MainActivity.REQUEST_CODE_REVIEWS -> {
+                REQUEST_CODE_REVIEWS -> {
                     channelId = NOTIFICATION_CHANNEL_REVIEWS_ID
                     notificationId = NOTIFICATION_ID_REVIEWS
                     pendingIntentCode = PENDING_INTENT_REVIEWS
                     title = context.getString(R.string.notification_title_reviews)
                     text = context.getString(R.string.notification_text_reviews)
                 }
-                MainActivity.REQUEST_CODE_LESSONS_AND_REVIEWS -> {
+                REQUEST_CODE_LESSONS_AND_REVIEWS -> {
                     channelId = NOTIFICATION_CHANNEL_LESSONS_AND_REVIEWS_ID
                     notificationId = NOTIFICATION_ID_LESSONS_AND_REVIEWS
                     pendingIntentCode = PENDING_INTENT_LESSONS_AND_REVIEWS

--- a/app/src/main/java/com/leapsoftware/leapforwanikani/workers/SummaryNotifyWorker.kt
+++ b/app/src/main/java/com/leapsoftware/leapforwanikani/workers/SummaryNotifyWorker.kt
@@ -56,7 +56,7 @@ class SummaryNotifyWorker(
             }
             is WKApiResponse.ApiSuccess -> {
                 Log.d(TAG, "SummaryWorker success.")
-                val requestCode = MainActivity.getActivityRequestCode(summary.responseData.data)
+                val requestCode = LeapNotificationManager.getRequestCode(summary.responseData.data)
                 LeapNotificationManager.sendNotification(applicationContext, requestCode)
                 repository.refreshLocalSummary(summary.responseData)
                 Result.success()


### PR DESCRIPTION
- Push notification fix as discussed in https://github.com/vrickey123/LeapForWaniKani/issues/23
- Added Extension functions to `ReviewRef` and `SummaryData` to house logic in central location
- Moved push notification logic from `MainActivity` to `LeapNotificationManager`
- Version bump to v1.0.1

Has Lessons and Reviews
- Push Opens Dashboard

Has Lessons
- Push Opens Lessons WebView

Has Reviews
- Push Opens Reviews WebView
